### PR TITLE
Attempt to fix CI build.

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -17,6 +17,6 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Build
-      run: cargo build --verbose
+      run: cargo build -p dirtydmg-core --verbose
     - name: Run tests
-      run: cargo test --verbose
+      run: cargo test -p dirtydmg-core --verbose


### PR DESCRIPTION
Temporary fix to only build and test dirtydmg-core.
dirtydmg-pc will be added back once I figure out how to deal with the sdl2
dependency issues.