### PR TITLE
Tried adding libsdl2 dependency to the build

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -18,8 +18,8 @@ jobs:
     - uses: actions/checkout@v2
     - name: Install Deps
       run: |
-        apt-get update -y -qq
-        apt-get install libsdl2-dev
+        sudo apt-get update -y -qq
+        sudo apt-get install libsdl2-dev
     - name: Build
       run: cargo build --verbose
     - name: Run tests

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -16,7 +16,11 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+    - name: Install Deps
+      run: |
+        apt-get update -y -qq
+        apt-get install libsdl2-dev
     - name: Build
-      run: cargo build -p dirtydmg-core --verbose
+      run: cargo build --verbose
     - name: Run tests
-      run: cargo test -p dirtydmg-core --verbose
+      run: cargo test --verbose


### PR DESCRIPTION
This should allow both dirtydmg-core and dirtydmg-pc to be built.