### PR TITLE
Patched up clippy errors.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -43,9 +43,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.126"
+version = "0.2.134"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "349d5a591cd28b49e1d1037471617a32ddcda5731b99419008085f72d5a53836"
+checksum = "329c933548736bc49fd575ee68c89e8be4d260064184389a5b77517cddd99ffb"
 
 [[package]]
 name = "sdl2"

--- a/dirtydmg-core/src/cartrige/mbc2.rs
+++ b/dirtydmg-core/src/cartrige/mbc2.rs
@@ -1,7 +1,7 @@
 use super::*;
 use byteorder::{WriteBytesExt, ReadBytesExt, LittleEndian};
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct Mbc2Cart {
     rom_offset: usize,
     ram_enabled: bool,

--- a/dirtydmg-core/src/cartrige/mbc3.rs
+++ b/dirtydmg-core/src/cartrige/mbc3.rs
@@ -2,7 +2,7 @@ use byteorder::{ReadBytesExt, WriteBytesExt, LittleEndian};
 
 use super::*;
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct Mbc3Cart {
     rom_offset: usize,
     ram_offset: usize, 

--- a/dirtydmg-core/src/cartrige/mbc5.rs
+++ b/dirtydmg-core/src/cartrige/mbc5.rs
@@ -2,7 +2,7 @@ use byteorder::{ReadBytesExt, WriteBytesExt, LittleEndian};
 
 use super::*;
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct Mbc5Cart {
     rom_offset: usize,
     ram_offset: usize, 

--- a/dirtydmg-core/src/cpu.rs
+++ b/dirtydmg-core/src/cpu.rs
@@ -36,7 +36,7 @@ enum Register {
 /// Registers are all represented in their smallest usable form.
 /// This means 16 bit registers are stored as two distinct 8 bit registers.
 /// 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct Regs {
     pub a:u8,
     pub f:u8,

--- a/dirtydmg-core/src/input.rs
+++ b/dirtydmg-core/src/input.rs
@@ -37,10 +37,7 @@ impl Gamepad{
     }
 
     fn is_dpad(button:&Button) -> bool{
-        match button {
-            Button::Up | Button::Down | Button::Left | Button::Right => {true}
-            _ => false
-        }
+        matches!(button, Button::Up | Button::Down | Button::Left | Button::Right)
     }
 
     fn get_mask(button:&Button) -> u8 {

--- a/dirtydmg-core/src/interface.rs
+++ b/dirtydmg-core/src/interface.rs
@@ -4,7 +4,7 @@
 /// Pixels are aranged in the bits such that the more significant the bits,
 /// the further right they are on the screen. The same applies to the byte
 /// Index, where higher values are farther right.
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct ScanlineBuffer {
     pub pixeldata: [u8;40]
 }

--- a/dirtydmg-core/src/interrupt.rs
+++ b/dirtydmg-core/src/interrupt.rs
@@ -2,7 +2,7 @@ use crate::bus::BusRW;
 use byteorder::{WriteBytesExt, ReadBytesExt};
 use std::io::{Read, Write};
 
-#[derive(PartialEq, Debug)]
+#[derive(PartialEq, Eq, Debug)]
 pub struct InterruptStatus {
     /// Interrupt status request byte. Use the assorted XXX_MASK constants to check for requests.
     pub isrreq: u8,

--- a/dirtydmg-core/src/sound/apu_control.rs
+++ b/dirtydmg-core/src/sound/apu_control.rs
@@ -2,7 +2,7 @@ use std::io::{Read, Write};
 use byteorder::{ReadBytesExt, WriteBytesExt};
 use super::{AudioChannel, AudioOutput};
 
-#[derive(PartialEq, Debug)]
+#[derive(PartialEq, Eq, Debug)]
 pub struct ApuControl {
     pub nr50: u8,
     pub nr51: u8,

--- a/dirtydmg-core/src/sound/channel1.rs
+++ b/dirtydmg-core/src/sound/channel1.rs
@@ -1,7 +1,7 @@
 use std::io::{Write, Read};
 use byteorder::{WriteBytesExt, ReadBytesExt, LittleEndian};
 
-#[derive(PartialEq, Debug)]
+#[derive(PartialEq, Eq, Debug)]
 pub struct Channel1{
     // Raw control registers
     pub nr10: u8,

--- a/dirtydmg-core/src/sound/channel2.rs
+++ b/dirtydmg-core/src/sound/channel2.rs
@@ -1,7 +1,7 @@
 use std::io::{Write, Read};
 use byteorder::{WriteBytesExt, ReadBytesExt, LittleEndian};
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct Channel2{
     // Raw control registers
     pub nr21: u8,

--- a/dirtydmg-core/src/sound/channel3.rs
+++ b/dirtydmg-core/src/sound/channel3.rs
@@ -2,7 +2,7 @@ use std::io::{Read, Write};
 use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
 use crate::bus::BusRW;
 
-#[derive(PartialEq, Debug)]
+#[derive(PartialEq, Eq, Debug)]
 pub struct Channel3{
     // Raw control registers
     pub nr30: u8,

--- a/dirtydmg-core/src/sound/channel4.rs
+++ b/dirtydmg-core/src/sound/channel4.rs
@@ -1,7 +1,7 @@
 use std::io::{Read, Write};
 use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
 
-#[derive(PartialEq, Debug)]
+#[derive(PartialEq, Eq, Debug)]
 pub struct Channel4{
     // Raw control registers
     pub nr41: u8,

--- a/dirtydmg-core/src/timer.rs
+++ b/dirtydmg-core/src/timer.rs
@@ -8,7 +8,7 @@ const TIMA_REG_ADDR:usize = 0xFF05;
 const TMA_REG_ADDR:usize  = 0xFF06;
 const TAC_REG_ADDR:usize  = 0xFF07;
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct TimerUnit {
     // Raw registers
     div:u8,


### PR DESCRIPTION
Derived Eq trait for most components.
Used `matches!` macro in place of manually checking a pattern.